### PR TITLE
Fix: apt repository with new signature key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 **/.DS_Store
 .vagrant/
 **/*.tar.gz
+config/apt_repo/keys/ansible.pub

--- a/images/Dockerfile.ubuntu.certified.aptrepo.readytoserve
+++ b/images/Dockerfile.ubuntu.certified.aptrepo.readytoserve
@@ -1,4 +1,4 @@
-FROM harishanand95/middleware-apt-packages:0.1
+FROM harishanand95/middleware-apt-packages:latest
 MAINTAINER Harish Anand "https://github.com/harishanand95"
 
 RUN apt-get update

--- a/install.yaml
+++ b/install.yaml
@@ -7,6 +7,7 @@
   tasks:
   - include: tasks/create_user.yml
   - include: tasks/update_repos.yml
+#  - include: tasks/apt_repo/create_apt_repository.yml
 
   - name: Start supervisor
     shell: service supervisor start

--- a/modules/download_packages.py
+++ b/modules/download_packages.py
@@ -1,6 +1,7 @@
 import urllib
 from utils import output_error, output_info, output_ok
 import traceback
+from pathlib2 import Path
 
 
 def download_file(url, filename, success_msg, failure_msg, log_file):
@@ -13,13 +14,17 @@ def download_file(url, filename, success_msg, failure_msg, log_file):
         failure_msg (string): failure message to be displayed when download fails
         log_file    (string): log file path
     """
-    try:
-        urllib.urlretrieve(url, filename)
+    my_file = Path(filename)
+    if my_file.is_file():
         output_ok(success_msg)
-    except Exception:
-        output_error(failure_msg + "\n           Check logs {0} for more details.".format(log_file),
-                     error_message=traceback.format_exc())
-        exit()
+    else:
+        try:
+            urllib.urlretrieve(url, filename)
+            output_ok(success_msg)
+        except Exception:
+            output_error(failure_msg + "\n           Check logs {0} for more details.".format(log_file),
+                         error_message=traceback.format_exc())
+            exit()
 
 
 def download(log_file):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pathlib2
 graphviz==0.8
 wheel==0.24.0
 

--- a/tasks/update_repos.yml
+++ b/tasks/update_repos.yml
@@ -1,7 +1,7 @@
 ---
 ## sudo apt-get update
   - name: Update repositories
-    shell: apt update
+    shell: sudo apt update
 
   - name: Install locales
     apt: name=locales state=present


### PR DESCRIPTION
Fixes a bug due to modified config/apt_repo/keys/ansible.pub.
This file should not be modified as it can lead to a mismatch with pub key of the image in docker hub. If it is modified, then it should match GPG sign used inside the https://hub.docker.com/r/harishanand95/middleware-apt-packages:latest docker cloud image.
