### PR TITLE
kong: support kong API management using konga

### DIFF
--- a/modules/install.py
+++ b/modules/install.py
@@ -285,6 +285,20 @@ def docker_setup(log_file, config_path="middleware.conf"):
                           log_file=log_file,
                           exit_on_fail=True)
 
+    cmd = 'docker run -d ' \
+          '-p 31337:1337 ' \
+          '--net mynet ' \
+          '--hostname=konga ' \
+          '--link kong:kong ' \
+          '--name konga ' \
+          '-e "NODE_ENV=production" ' \
+          'pantsel/konga'
+
+    subprocess_with_print(cmd,
+                          success_msg="Created KONGA docker instance. ",
+                          failure_msg="Creation of KONGA docker instance failed.",
+                          log_file=log_file,
+                          exit_on_fail=True)
     create_ansible_host_file(instance_details)
 
 

--- a/modules/start.py
+++ b/modules/start.py
@@ -6,6 +6,7 @@ def start_all():
     """ Starts all docker containers, OpenBSD vagrant files. """
     create_hosts()
     subprocess.call("docker start pushpin", shell=True)
+    subprocess.call("docker start konga", shell=True)
     subprocess.call('vagrant up', shell=True)
     subprocess.call('ansible-playbook -i hosts start.yaml', shell=True)
 

--- a/smartcity-middleware.py
+++ b/smartcity-middleware.py
@@ -28,7 +28,7 @@ def install(arguments):
         container_setup.docker_setup(log_file=arguments.log_file, config_path=arguments.config_file)
         # TODO: RabbitMQ, Catalogue fails due to network issues. Temporary fix is to run the setup again
         #       limiting the installation only to RabbitMQ and catalogue
-        #       python setup.py -l hypercat,rabbitmq -f middleware.conf
+        #       python smartcity-middleware.py -l hypercat,rabbitmq -f middleware.conf
         container_setup.ansible_setup("kong, rabbitmq, hypercat, apt_repo, tomcat")
 
 


### PR DESCRIPTION
Konga, a web-based kong management tool will
be available at port 31337 with the default Konga
user account. Konga can be used for managing API's, 
consumers. It has the feature to notify admin via
email when any of the API is down.

 https://pantsel.github.io/konga/

Fixes #4 
