### PR TITLE
Fix: missing RegisterAPI.war file in linux setup

### DIFF
--- a/middleware.conf
+++ b/middleware.conf
@@ -39,5 +39,5 @@ DATA_STORAGE = /data/catalogue
 
 [SYSTEM_CONFIG]
 SSH_PUBLIC_KEY = ~/.ssh/id_rsa.pub
-OS = linux # only "linux" and "macOS" terms are supported
+OS = linux
 #OS = macOS


### PR DESCRIPTION
The comment mentioned after the `OS=linux` is removed. This comment was getting selected for the OS parameter, which is not needed.