### PR TITLE
Fix: Ansible unarchive failure

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -205,7 +205,8 @@
   - name: Extract schemas.zip into schemas dir
     unarchive:
       src: /home/ansible/cat-json-schema-server/schemas.zip
-      dest: /home/ansible/cat-json-schema-server/schemas
+      dest: /home/ansible/cat-json-schema-server
+      remote_src: yes
 
   - name: Change cat-json-schema-server ldap IP port
     command: sed -i 's/10.156.14.20:389/ldapd:8389/g' config.js


### PR DESCRIPTION
Failure is due to the missing `remote_src`