### PR TITLE
Fix: supervisor unix socket adjusted for overlay2 issues

### DIFF
--- a/config/apt_repo/supervisor.conf
+++ b/config/apt_repo/supervisor.conf
@@ -1,0 +1,28 @@
+; supervisor config file
+
+[unix_http_server]
+file=/dev/shm/supervisor.sock   ; (the path to the socket file)
+chmod=0700                       ; sockef file mode (default 0700)
+
+[supervisord]
+logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
+pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+childlogdir=/var/log/supervisor            ; ('AUTO' child log dir, default $TEMP)
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///dev/shm/supervisor.sock ; use a unix:// URL  for a unix socket
+
+; The [include] section can just contain the "files" setting.  This
+; setting can list multiple files (separated by whitespace or
+; newlines).  It can also contain wildcards.  The filenames are
+; interpreted as relative to this file.  Included files *cannot*
+; include files themselves.
+
+[include]
+files = /etc/supervisor/conf.d/*.conf

--- a/install.yaml
+++ b/install.yaml
@@ -15,6 +15,11 @@
       dest: 'config/apt_repo/keys/ansible.pub'
       flat: yes
 
+  - name: Setting up supervisor.conf
+    copy:
+      src: config/apt_repo/supervisor.conf
+      dest: /etc/supervisor/supervisor.conf
+
   - name: Start supervisor
     shell: service supervisor start
 
@@ -92,6 +97,11 @@
   - name: Install supervisor
     apt: name=supervisor state=present
 
+  - name: Setting up supervisor.conf
+    copy:
+      src: config/apt_repo/supervisor.conf
+      dest: /etc/supervisor/supervisor.conf
+
   - name: Setting up RabbitMQ configuration
     copy:
       src: config/rabbitmq/rabbitmq.config
@@ -159,6 +169,11 @@
 
   - name: Install supervisor
     apt: name=supervisor state=present
+
+  - name: Setting up supervisor.conf
+    copy:
+      src: config/apt_repo/supervisor.conf
+      dest: /etc/supervisor/supervisor.conf
 
   - name: Install screen
     apt: name=screen state=present
@@ -294,6 +309,11 @@
 
   - name: Install supervisor
     apt: name=supervisor state=present
+
+  - name: Setting up supervisor.conf
+    copy:
+      src: config/apt_repo/supervisor.conf
+      dest: /etc/supervisor/supervisor.conf
 
   - name: Copy supervisor-kong.conf
     copy:
@@ -642,6 +662,11 @@
 
   - name: Install supervisor
     apt: name=supervisor state=present
+
+  - name: Setting up supervisor.conf
+    copy:
+      src: config/apt_repo/supervisor.conf
+      dest: /etc/supervisor/supervisor.conf
 
   - name: Copy tomcat.conf
     copy:

--- a/install.yaml
+++ b/install.yaml
@@ -18,7 +18,7 @@
   - name: Setting up supervisor.conf
     copy:
       src: config/apt_repo/supervisor.conf
-      dest: /etc/supervisor/supervisor.conf
+      dest: /etc/supervisor/supervisord.conf
 
   - name: Start supervisor
     shell: service supervisor start
@@ -100,7 +100,7 @@
   - name: Setting up supervisor.conf
     copy:
       src: config/apt_repo/supervisor.conf
-      dest: /etc/supervisor/supervisor.conf
+      dest: /etc/supervisor/supervisord.conf
 
   - name: Setting up RabbitMQ configuration
     copy:
@@ -173,7 +173,7 @@
   - name: Setting up supervisor.conf
     copy:
       src: config/apt_repo/supervisor.conf
-      dest: /etc/supervisor/supervisor.conf
+      dest: /etc/supervisor/supervisord.conf
 
   - name: Install screen
     apt: name=screen state=present
@@ -313,7 +313,7 @@
   - name: Setting up supervisor.conf
     copy:
       src: config/apt_repo/supervisor.conf
-      dest: /etc/supervisor/supervisor.conf
+      dest: /etc/supervisor/supervisord.conf
 
   - name: Copy supervisor-kong.conf
     copy:
@@ -666,7 +666,7 @@
   - name: Setting up supervisor.conf
     copy:
       src: config/apt_repo/supervisor.conf
-      dest: /etc/supervisor/supervisor.conf
+      dest: /etc/supervisor/supervisord.conf
 
   - name: Copy tomcat.conf
     copy:

--- a/modules/install.py
+++ b/modules/install.py
@@ -370,7 +370,6 @@ def create_instance(server, image, log_file, storage_host="", storage_guest="", 
                          "\n           Check logs {0} for more details.".format(log_file),
                          error_message=traceback.format_exc())
             exit()
-
     elif server == "rabbitmq":  # separate rabbitmq log storage needed
         ssh = config.get('RABBITMQ', 'SSH')
         http = config.get('RABBITMQ', 'HTTP')
@@ -391,7 +390,6 @@ def create_instance(server, image, log_file, storage_host="", storage_guest="", 
                          "\n           Check logs {0} for more details.".format(log_file),
                          error_message=traceback.format_exc())
             exit()
-
     elif server == "tomcat":  # separate tomcat log storage needed
         ssh = config.get('TOMCAT', 'SSH')
         http = config.get('TOMCAT', 'HTTP')
@@ -408,7 +406,6 @@ def create_instance(server, image, log_file, storage_host="", storage_guest="", 
                          "\n           Check logs {0} for more details.".format(log_file),
                          error_message=traceback.format_exc())
             exit()
-
     elif server == "hypercat":  # separate data storage needed
         ssh = config.get('CATALOGUE', 'SSH')
         http = config.get('CATALOGUE', 'HTTP')


### PR DESCRIPTION
Please read this issue for more info:
https://github.com/moby/moby/issues/12080#ref-issue-117814708

The other fix is to make `/var/run/` directory to be `tmpfs` which is avoided for now. (This approach will be done if any further related issues occurs)